### PR TITLE
Add clamp to "volume"

### DIFF
--- a/Patches/NonGamePatches.cs
+++ b/Patches/NonGamePatches.cs
@@ -66,7 +66,7 @@ namespace BiggerLobby.Patches
                         playerControllerB2.currentVoiceChatIngameSettings.set2D = true;
                         if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                         {
-                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                            _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value), 0f, 1f));
                         }
                     }
                     else
@@ -124,7 +124,7 @@ namespace BiggerLobby.Patches
                 {*/
                 if (playerControllerB2.currentVoiceChatIngameSettings != null && playerControllerB2.currentVoiceChatIngameSettings._playbackComponent != null)
                 {
-                    _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                    _playbackVolumeProperty.SetValue(playerControllerB2.currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[i] + 1) * (2 * Plugin._LoudnessMultiplier.Value)), 0f, 1f);
                 }
             }
         }
@@ -158,7 +158,7 @@ namespace BiggerLobby.Patches
                 //Debug.Log(__instance.playerVoiceVolumes[j].ToString() + $"PlayerVolume{j}"); dont do this shit its annoying 
                 //__instance.diageticMixer.SetFloat($"PlayerVolume{j}", 16f * __instance.playerVoiceVolumes[j]);
                 if (StartOfRound.Instance.allPlayerScripts[j].voicePlayerState != null) {
-                    (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("Dissonance.Audio.Playback.IVoicePlaybackInternal.PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(StartOfRound.Instance.allPlayerScripts[j].currentVoiceChatIngameSettings._playbackComponent, (SoundManager.Instance.playerVoiceVolumes[j] + 1) * (2 * Plugin._LoudnessMultiplier.Value));
+                    (typeof(Dissonance.Audio.Playback.VoicePlayback).GetProperty("Dissonance.Audio.Playback.IVoicePlaybackInternal.PlaybackVolume", BindingFlags.NonPublic | BindingFlags.Instance)).SetValue(StartOfRound.Instance.allPlayerScripts[j].currentVoiceChatIngameSettings._playbackComponent, Mathf.Clamp((SoundManager.Instance.playerVoiceVolumes[j] + 1) * (2 * Plugin._LoudnessMultiplier.Value)), 0f, 1f);
                 }
                 if (Mathf.Abs(__instance.playerVoicePitches[j] - __instance.playerVoicePitchTargets[j]) > 0.025f)
                 {


### PR DESCRIPTION
Hello, thank you for creating/maintaining BiggerLobby!

The BiggerLobby tries to set volume above 1f sometimes. Which causes an error and prevents "UpdatePlayerVoiceEffects" run properly. Which also prevents my mod (MoreScreams) to run properly too. I've clamped it.

For reference, here a part from my log without this patch:

```c#
[Error  : Unity Log] ArgumentOutOfRangeException: Volume must be between 0 and 1
Parameter name: value
Stack trace:
Dissonance.RemoteVoicePlayerState.set_Volume (System.Single value) (at <e92564caf0834e68898e38932a2c2ea2>:0)
MoreScreams.Patches.UpdatePlayerVoiceEffectsPatch.Postfix () (at <61dc102499a6435e91744621e1495ab9>:0)
(wrapper dynamic-method) StartOfRound.DMD<StartOfRound::UpdatePlayerVoiceEffects>(StartOfRound)
GameNetcodeStuff.PlayerControllerB.KillPlayerClientRpc (System.Int32 playerId, System.Boolean spawnBody, UnityEngine.Vector3 bodyVelocity, System.Int32 causeOfDeath, System.Int32 deathAnimation) (at <39ddadb2aa5843e586a6c642ee60b0b5>:0)
GameNetcodeStuff.PlayerControllerB.__rpc_handler_168339603 (Unity.Netcode.NetworkBehaviour target, Unity.Netcode.FastBufferReader reader, Unity.Netcode.__RpcParams rpcParams) (at <39ddadb2aa5843e586a6c642ee60b0b5>:0)
Unity.Netcode.RpcMessageHelpers.Handle (Unity.Netcode.NetworkContext& context, Unity.Netcode.RpcMetadata& metadata, Unity.Netcode.FastBufferReader& payload, Unity.Netcode.__RpcParams& rpcParams) (at <1b23ec5fcbfc4fbca0db70afcdb9b715>:0)
Rethrow as Exception: Unhandled RPC exception!
UnityEngine.Debug:LogException(Exception)
Unity.Netcode.RpcMessageHelpers:Handle(NetworkContext&, RpcMetadata&, FastBufferReader&, __RpcParams&)
Unity.Netcode.ClientRpcMessage:Handle(NetworkContext&)
Unity.Netcode.NetworkMessageManager:ReceiveMessage(FastBufferReader, NetworkContext&, NetworkMessageManager)
Unity.Netcode.NetworkMessageManager:HandleMessage(NetworkMessageHeader&, FastBufferReader, UInt64, Single, Int32)
Unity.Netcode.NetworkMessageManager:ProcessIncomingMessageQueue()
Unity.Netcode.NetworkManager:NetworkUpdate(NetworkUpdateStage)
Unity.Netcode.NetworkUpdateLoop:RunNetworkUpdateStage(NetworkUpdateStage)
Unity.Netcode.<>c:<CreateLoopSystem>b__0_0()
```
